### PR TITLE
Enable GitHub Pages site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # dunjy-krawl
 Dunjy Krawl: A lightweight web-based dungeon crawler by Ben Gothard
+
+## GitHub Pages
+The repository is configured with a GitHub Actions workflow that publishes the
+contents of the `main` branch to GitHub Pages. Once the repository owner
+enables the *GitHub Pages* feature, the latest version will be available at:
+
+```
+https://<your-github-username>.github.io/dunjy-krawl/
+```
+
+Simply push changes to `main` and the site will automatically deploy so anyone
+can play the game from their browser.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy the site to GitHub Pages
- document the GitHub Pages URL in the README

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68433d9a8290832a912af73326a21b89