### PR TITLE
Add arrow limit and mouse-based aiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ can play the game from their browser.
 
 - Move with arrow keys or **WASD**
 - Press **Space** to swing your weapon at the tile in front of you
-- Press **F** to fire an arrow in the direction you're facing
+- Press **F** to fire an arrow toward the mouse pointer
+  - You start with 10 arrows displayed on the HUD
 

--- a/main.js
+++ b/main.js
@@ -13,6 +13,8 @@ let dungeon = [];
 let player = { x: 1, y: 1, hp: 3, dir: { x: 0, y: 1 } };
 let enemies = [];
 let projectiles = [];
+let arrowCount = 10;
+let mouseTile = { x: 0, y: 0 };
 
 // Movement timing (in ms) to slow things down
 const PLAYER_MOVE_DELAY = 150;
@@ -205,7 +207,7 @@ function render() {
   // Draw HUD: Player HP
   ctx.fillStyle = '#fff';
   ctx.font = '16px sans-serif';
-  ctx.fillText('HP: ' + player.hp, 10, 20);
+  ctx.fillText('HP: ' + player.hp + '  Arrows: ' + arrowCount, 10, 20);
 }
 
 // Basic input handling
@@ -230,6 +232,15 @@ window.addEventListener(
   },
   false
 );
+
+// Track mouse position relative to the canvas
+canvas.addEventListener('mousemove', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
+  mouseTile.x = Math.floor(mx / TILE_SIZE);
+  mouseTile.y = Math.floor(my / TILE_SIZE);
+});
 
 // Move player if no wall ahead
 function updatePlayer() {
@@ -295,10 +306,12 @@ function updateEnemies() {
 
 // Arrow projectile handling
 function shootArrow() {
-  const dx = player.dir.x;
-  const dy = player.dir.y;
+  if (arrowCount <= 0) return;
+  const dx = Math.sign(mouseTile.x - player.x);
+  const dy = Math.sign(mouseTile.y - player.y);
   if (dx === 0 && dy === 0) return;
   projectiles.push({ x: player.x + dx, y: player.y + dy, dx, dy });
+  arrowCount--;
 }
 
 function swingWeapon() {


### PR DESCRIPTION
## Summary
- support tracking of mouse tile to aim arrows
- limit player to 10 arrows and display remaining count on HUD
- stop firing when out of arrows
- update README with new arrow controls

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843451e1e38832ab478d72fd5ee4986