### PR TITLE
Add restart with game over overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ can play the game from their browser.
 - Press **Space** to swing your weapon at the tile in front of you
 - Press **F** to fire an arrow toward the mouse pointer
   - You start with 10 arrows displayed on the HUD
+- Press **R** to restart after a Game Over
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <canvas id="gameCanvas" width="800" height="600"></canvas>
-  <p style="text-align:center;margin-top:10px">Use arrow keys/WASD to move. Press <strong>Space</strong> to attack and <strong>F</strong> to shoot.</p>
+  <p style="text-align:center;margin-top:10px">Use arrow keys/WASD to move. Press <strong>Space</strong> to attack, <strong>F</strong> to shoot, and <strong>R</strong> to restart after dying.</p>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -243,6 +243,12 @@ let keysDown = {};
 window.addEventListener(
   'keydown',
   (e) => {
+    // restart if game over and R is pressed
+    if (!gameRunning && e.key.toLowerCase() === 'r') {
+      init();
+      return;
+    }
+
     keysDown[e.key] = true;
     if (e.code === 'Space') {
       swingWeapon();
@@ -389,6 +395,17 @@ function checkCollisions() {
 
 let gameRunning = true;
 
+function drawGameOver() {
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#fff';
+  ctx.font = '32px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2 - 20);
+  ctx.font = '20px sans-serif';
+  ctx.fillText('Press R to restart', canvas.width / 2, canvas.height / 2 + 20);
+}
+
 // Main game loop
 // Update all game entities
 function update() {
@@ -400,7 +417,11 @@ function update() {
 
 // Main game loop
 function gameLoop() {
-  if (!gameRunning) return;
+  if (!gameRunning) {
+    render();
+    drawGameOver();
+    return;
+  }
   update();
   render();
   requestAnimationFrame(gameLoop);
@@ -408,7 +429,9 @@ function gameLoop() {
 
 // Entry point
 function init() {
+  arrowCount = 10;
   generateDungeon();
+  gameRunning = true;
   gameLoop();
 }
 


### PR DESCRIPTION
## Summary
- show restart instructions in README and index.html
- allow pressing **R** to restart the dungeon
- display overlay on game over so restarting is clearer

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_684359a35da0832a997c701e0820712f