### PR TITLE
Fix start screen crash with empty dungeon

### DIFF
--- a/main.js
+++ b/main.js
@@ -471,12 +471,15 @@ function update() {
 
 // Main game loop
 function gameLoop() {
-  render();
   if (gameState === 'start') {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
     drawStartScreen();
   } else if (gameState === 'running') {
     update();
+    render();
   } else if (gameState === 'gameover') {
+    render();
     drawGameOver();
   }
   requestAnimationFrame(gameLoop);


### PR DESCRIPTION
## Summary
- avoid rendering tiles before a level is generated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848d9f316f8832ab3515db272f4279b