### PR TITLE
Improve UI with retro styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ now features simple character sprites so the player and enemies look more like
 people and monsters instead of plain squares. It now includes multiple levels
 that loop endlessly, increasing difficulty each time you clear all stages.
 
+The interface has been overhauled with a vibrant retro theme powered by the
+"Press Start 2P" font and polished styling so the game looks as fun as it
+plays.
+
 The start screen now proclaims **"Dunjy Krawl: Epic Quest"**, inviting players
 to embark on an unforgettable adventure as soon as they load the page.
 

--- a/index.html
+++ b/index.html
@@ -5,10 +5,19 @@
   <title>Dunjy Krawl</title>
   <meta name="author" content="Ben Gothard" />
   <link rel="stylesheet" href="style.css" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+    rel="stylesheet"
+  />
 </head>
 <body>
-  <canvas id="gameCanvas" width="800" height="600"></canvas>
-  <p style="text-align:center;margin-top:10px">Use arrow keys/WASD to move. Press <strong>Space</strong> to attack, <strong>F</strong> to shoot, and <strong>R</strong> to restart after dying.</p>
+  <div id="gameWrapper">
+    <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <p class="instructions">
+      Use arrow keys/WASD to move. Press <strong>Space</strong> to attack,
+      <strong>F</strong> to shoot, and <strong>R</strong> to restart after dying.
+    </p>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -241,7 +241,7 @@ function render() {
 
   // Draw HUD: Player HP
   ctx.fillStyle = '#fff';
-  ctx.font = '16px sans-serif';
+  ctx.font = '16px "Press Start 2P", sans-serif';
   ctx.fillText('HP: ' + player.hp + '  Arrows: ' + arrowCount +
     '  Level: ' + level + '  Difficulty: ' + difficulty, 10, 20);
 }
@@ -412,10 +412,10 @@ function drawGameOver() {
   ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#fff';
-  ctx.font = '32px sans-serif';
+  ctx.font = '32px "Press Start 2P", sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2 - 20);
-  ctx.font = '20px sans-serif';
+  ctx.font = '20px "Press Start 2P", sans-serif';
   ctx.fillText('Press R to restart', canvas.width / 2, canvas.height / 2 + 20);
 }
 
@@ -423,20 +423,20 @@ function drawStartScreen() {
   ctx.fillStyle = '#000';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#fff';
-  ctx.font = 'bold 48px sans-serif';
+  ctx.font = 'bold 48px "Press Start 2P", sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText(
     'Dunjy Krawl: Epic Quest',
     canvas.width / 2,
     canvas.height / 2 - 50
   );
-  ctx.font = '24px sans-serif';
+  ctx.font = '24px "Press Start 2P", sans-serif';
   ctx.fillText(
     'An Epic Adventure Awaits',
     canvas.width / 2,
     canvas.height / 2 - 10
   );
-  ctx.font = '20px sans-serif';
+  ctx.font = '20px "Press Start 2P", sans-serif';
   ctx.fillText('Press Enter to begin', canvas.width / 2, canvas.height / 2 + 40);
 }
 

--- a/style.css
+++ b/style.css
@@ -4,14 +4,25 @@
   box-sizing: border-box;
 }
 body {
-  background: #111;
+  background: linear-gradient(#222, #000);
   color: #fff;
-  font-family: sans-serif;
+  font-family: 'Press Start 2P', sans-serif;
+  padding: 20px 0;
+}
+
+#gameWrapper {
+  text-align: center;
 }
 canvas {
   display: block;
-  margin: 20px auto;
+  margin: 0 auto;
   background: #222;
-  border: 2px solid #555;
+  border: 4px solid #555;
+  box-shadow: 0 0 20px #000;
   image-rendering: pixelated;
+}
+
+.instructions {
+  margin-top: 12px;
+  font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- embed Press Start 2P font for a retro look
- center the canvas inside a wrapper and style instructions
- give body a gradient background and fancy canvas border
- update start screen and HUD fonts to use Press Start 2P
- document the new theme in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e2df6220832a9ce31d911c058e0c