### PR TITLE
Reduce font sizes to fit board

### DIFF
--- a/main.js
+++ b/main.js
@@ -241,7 +241,7 @@ function render() {
 
   // Draw HUD: Player HP
   ctx.fillStyle = '#fff';
-  ctx.font = '16px "Press Start 2P", sans-serif';
+  ctx.font = '14px "Press Start 2P", sans-serif';
   ctx.fillText('HP: ' + player.hp + '  Arrows: ' + arrowCount +
     '  Level: ' + level + '  Difficulty: ' + difficulty, 10, 20);
 }
@@ -412,10 +412,10 @@ function drawGameOver() {
   ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#fff';
-  ctx.font = '32px "Press Start 2P", sans-serif';
+  ctx.font = '24px "Press Start 2P", sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2 - 20);
-  ctx.font = '20px "Press Start 2P", sans-serif';
+  ctx.font = '16px "Press Start 2P", sans-serif';
   ctx.fillText('Press R to restart', canvas.width / 2, canvas.height / 2 + 20);
 }
 
@@ -423,20 +423,20 @@ function drawStartScreen() {
   ctx.fillStyle = '#000';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = '#fff';
-  ctx.font = 'bold 48px "Press Start 2P", sans-serif';
+  ctx.font = 'bold 32px "Press Start 2P", sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText(
     'Dunjy Krawl: Epic Quest',
     canvas.width / 2,
     canvas.height / 2 - 50
   );
-  ctx.font = '24px "Press Start 2P", sans-serif';
+  ctx.font = '18px "Press Start 2P", sans-serif';
   ctx.fillText(
     'An Epic Adventure Awaits',
     canvas.width / 2,
     canvas.height / 2 - 10
   );
-  ctx.font = '20px "Press Start 2P", sans-serif';
+  ctx.font = '14px "Press Start 2P", sans-serif';
   ctx.fillText('Press Enter to begin', canvas.width / 2, canvas.height / 2 + 40);
 }
 

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   background: linear-gradient(#222, #000);
   color: #fff;
   font-family: 'Press Start 2P', sans-serif;
-  padding: 20px 0;
+  padding: 10px 0;
 }
 
 #gameWrapper {
@@ -23,6 +23,6 @@ canvas {
 }
 
 .instructions {
-  margin-top: 12px;
-  font-size: 12px;
+  margin-top: 8px;
+  font-size: 10px;
 }


### PR DESCRIPTION
## Summary
- reduce body padding and instruction text size
- shrink fonts in HUD, start screen and game over screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e4e494e0832a9d24a7be1202bca9